### PR TITLE
Capacity Question

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -260,6 +260,13 @@ func launchNonInteractive(h *ec2helper.EC2Helper) {
 
 	confirmation := question.AskConfirmationWithInput(simpleConfig, detailedConfig, false)
 
+	isOnDemand := question.AskSpotOrOnDemand()
+
+	if isOnDemand == cli.ResponseNo {
+		LaunchSpotInstance(h, simpleConfig, detailedConfig, confirmation)
+		return
+	}
+
 	// Launch the instance.
 	_, err = h.LaunchInstance(simpleConfig, detailedConfig, confirmation == cli.ResponseYes)
 	if cli.ShowError(err, "Launching instance failed") {
@@ -633,5 +640,13 @@ func ReadSaveConfig(simpleConfig *config.SimpleInfo) {
 	if isSaveRequired {
 		err := config.SaveConfig(simpleConfig, nil)
 		cli.ShowError(err, "Saving config file failed")
+	}
+}
+
+func LaunchSpotInstance(h *ec2helper.EC2Helper, simpleConfig *config.SimpleInfo, detailedConfig *config.DetailedInfo, confirmation string) {
+	fmt.Println("Spot Instance Testing")
+	_, err := h.LaunchInstance(simpleConfig, detailedConfig, confirmation == cli.ResponseYes)
+	if cli.ShowError(err, "Launching instance failed") {
+		return
 	}
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -38,8 +38,6 @@ var launchCmd = &cobra.Command{
 	Run: launch,
 }
 
-const onDemandText = "On-Demand"
-
 // Add flags
 func init() {
 	rootCmd.AddCommand(launchCmd)
@@ -155,7 +153,6 @@ func launchInteractive(h *ec2helper.EC2Helper) {
 	var detailedConfig *config.DetailedInfo
 	var confirmation string
 	var capacityTypeAnswer string
-	onDemandText := "On-Demand"
 	for {
 		// Parse config first
 		detailedConfig, err = h.ParseConfig(simpleConfig)
@@ -218,7 +215,7 @@ func launchInteractive(h *ec2helper.EC2Helper) {
 	}
 
 	// Launch On-Demand or Spot instance based on capacity type
-	if simpleConfig.CapacityType == onDemandText {
+	if simpleConfig.CapacityType == question.CapacityTypes.OnDemand {
 		_, err = h.LaunchInstance(simpleConfig, detailedConfig, confirmation == cli.ResponseYes)
 	} else {
 		err = LaunchSpotInstance(h, simpleConfig, detailedConfig, confirmation)
@@ -274,7 +271,7 @@ func launchNonInteractive(h *ec2helper.EC2Helper) {
 	confirmation := question.AskConfirmationWithInput(simpleConfig, detailedConfig, false)
 
 	// Launch On-Demand or Spot instance based on capacity type
-	if simpleConfig.CapacityType == onDemandText {
+	if simpleConfig.CapacityType == question.CapacityTypes.OnDemand {
 		_, err = h.LaunchInstance(simpleConfig, detailedConfig, confirmation == cli.ResponseYes)
 	} else {
 		err = LaunchSpotInstance(h, simpleConfig, detailedConfig, confirmation)

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -215,16 +215,7 @@ func launchInteractive(h *ec2helper.EC2Helper) {
 	}
 
 	// Launch On-Demand or Spot instance based on capacity type
-	if simpleConfig.CapacityType == question.CapacityTypes.OnDemand {
-		_, err = h.LaunchInstance(simpleConfig, detailedConfig, confirmation == cli.ResponseYes)
-	} else {
-		err = LaunchSpotInstance(h, simpleConfig, detailedConfig, confirmation)
-	}
-
-	if cli.ShowError(err, "Launching instance failed") {
-		return
-	}
-	ReadSaveConfig(simpleConfig)
+	LaunchCapacityInstance(h, simpleConfig, detailedConfig, confirmation)
 }
 
 // Launch the instance non-interactively
@@ -270,8 +261,13 @@ func launchNonInteractive(h *ec2helper.EC2Helper) {
 
 	confirmation := question.AskConfirmationWithInput(simpleConfig, detailedConfig, false)
 
-	// Launch On-Demand or Spot instance based on capacity type
-	if simpleConfig.CapacityType == question.CapacityTypes.OnDemand {
+	LaunchCapacityInstance(h, simpleConfig, detailedConfig, confirmation)
+}
+
+// Launch On-Demand or Spot instance based on capacity type
+func LaunchCapacityInstance(h *ec2helper.EC2Helper, simpleConfig *config.SimpleInfo, detailedConfig *config.DetailedInfo, confirmation string) {
+	var err error
+	if simpleConfig.CapacityType == question.DefaultCapacityTypeText.OnDemand {
 		_, err = h.LaunchInstance(simpleConfig, detailedConfig, confirmation == cli.ResponseYes)
 	} else {
 		err = LaunchSpotInstance(h, simpleConfig, detailedConfig, confirmation)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -40,6 +40,7 @@ const (
 	ResourceIamInstanceProfile       = "IAM Instance Profile"
 	ResourceBootScriptFilePath       = "Boot Script Filepath"
 	ResourceUserTags                 = "Tag Specification(key|value)"
+	ResourceCapacityType             = "Capacity Type"
 )
 
 // Show errors if there are any. Return true when there are errors, and false when there is none

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ type SimpleInfo struct {
 	IamInstanceProfile            string
 	BootScriptFilePath            string
 	UserTags                      map[string]string
+	CapacityType                  string
 }
 
 /*

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,11 +53,12 @@ const testLaunchTemplateVersion = "1"
 const testNewVPC = true
 const testIamProfile = "iam-profile"
 const testBootScriptFilePath = "some/path/to/bootscript"
+const testCapacityType = "On-Spot-Demand"
 
 var testTags = map[string]string{"testedBy": "BRYAN", "brokenBy": "CBASKIN"}
 var testSecurityGroup = []string{"sg-12345", "sg-67890"}
 
-const expectedJson = `{"Region":"us-somewhere","ImageId":"ami-12345","InstanceType":"t2.micro","SubnetId":"s-12345","LaunchTemplateId":"lt-12345","LaunchTemplateVersion":"1","SecurityGroupIds":["sg-12345","sg-67890"],"NewVPC":true,"AutoTerminationTimerMinutes":0,"KeepEbsVolumeAfterTermination":false,"IamInstanceProfile":"iam-profile","BootScriptFilePath":"some/path/to/bootscript","UserTags":{"brokenBy":"CBASKIN","testedBy":"BRYAN"}}`
+const expectedJson = `{"Region":"us-somewhere","ImageId":"ami-12345","InstanceType":"t2.micro","SubnetId":"s-12345","LaunchTemplateId":"lt-12345","LaunchTemplateVersion":"1","SecurityGroupIds":["sg-12345","sg-67890"],"NewVPC":true,"AutoTerminationTimerMinutes":0,"KeepEbsVolumeAfterTermination":false,"IamInstanceProfile":"iam-profile","BootScriptFilePath":"some/path/to/bootscript","UserTags":{"brokenBy":"CBASKIN","testedBy":"BRYAN"},"CapacityType":"On-Spot-Demand"}`
 
 func TestSaveConfig(t *testing.T) {
 	testConfig := &config.SimpleInfo{
@@ -72,6 +73,7 @@ func TestSaveConfig(t *testing.T) {
 		IamInstanceProfile:    testIamProfile,
 		BootScriptFilePath:    testBootScriptFilePath,
 		UserTags:              testTags,
+		CapacityType:          testCapacityType,
 	}
 
 	err := config.SaveConfig(testConfig, aws.String(testConfigFileName))
@@ -126,6 +128,7 @@ func TestReadConfig(t *testing.T) {
 		IamInstanceProfile:    testIamProfile,
 		BootScriptFilePath:    testBootScriptFilePath,
 		UserTags:              testTags,
+		CapacityType:          testCapacityType,
 	}
 	th.Equals(t, expectedConfig, actualConfig)
 }

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -1119,6 +1119,8 @@ func (h *EC2Helper) GetDefaultSimpleConfig() (*config.SimpleInfo, error) {
 		simpleConfig.SecurityGroupIds = []string{*defaultSg.GroupId}
 	}
 
+	simpleConfig.CapacityType = "On-Demand"
+
 	return simpleConfig, nil
 }
 

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -1164,6 +1164,12 @@ func (h *EC2Helper) LaunchInstance(simpleConfig *config.SimpleInfo, detailedConf
 	}
 }
 
+func (h *EC2Helper) LaunchSpotInstance(simpleConfig *config.SimpleInfo, detailedConfig *config.DetailedInfo, confirmation string) (err error) {
+	fmt.Println("Spot Instance Testing")
+	_, err = h.LaunchInstance(simpleConfig, detailedConfig, confirmation == cli.ResponseYes)
+	return
+}
+
 // Create a new stack and update simpleConfig for config saving
 func (h *EC2Helper) createNetworkConfiguration(simpleConfig *config.SimpleInfo,
 	input *ec2.RunInstancesInput) error {

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -38,7 +38,7 @@ import (
 
 const yesNoOption = "[ yes / no ]"
 
-var CapacityTypes = struct {
+var DefaultCapacityTypeText = struct {
 	OnDemand, Spot string
 }{
 	OnDemand: "On-Demand",
@@ -1199,9 +1199,9 @@ func AskTerminationConfirmation(instanceIds []string) string {
 
 func AskCapacityType() string {
 	question := fmt.Sprintf("Select capacity type. Spot instances are available at up to a 90%% discount compared to On-Demand instances,\nbut they may get interrupted by EC2 with a 2-minute warning")
-	defaultInstanceTypeText := CapacityTypes.OnDemand
+	defaultInstanceTypeText := DefaultCapacityTypeText.OnDemand
 	optionsText := "1. On-Demand\n2. Spot\n"
-	indexedOptions := []string{CapacityTypes.OnDemand, CapacityTypes.Spot}
+	indexedOptions := []string{DefaultCapacityTypeText.OnDemand, DefaultCapacityTypeText.Spot}
 
 	answer := AskQuestion(&AskQuestionInput{
 		QuestionString: question,

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -932,6 +932,7 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 		{cli.ResourceVpc, vpcInfo},
 		{cli.ResourceSubnet, subnetInfo},
 		{cli.ResourceInstanceType, simpleConfig.InstanceType},
+		{cli.ResourceCapacityType, simpleConfig.CapacityType},
 		{cli.ResourceImage, simpleConfig.ImageId},
 	}
 
@@ -1189,11 +1190,11 @@ func AskTerminationConfirmation(instanceIds []string) string {
 	return answer
 }
 
-func AskSpotOrOnDemand() string {
-	question := "Select instance type. Spot is price efficient and effective for short term use"
+func AskCapacityType() string {
+	question := "Select capacity type. Spot instances are available at up to a 90 %% discount compared to On-Demand instances,\nbut they may get interrupted by EC2 with a 2-minute warning"
 	defaultInstanceTypeText := "On-Demand"
 	optionsText := "1. On-Demand\n2. Spot\n"
-	indexedOptions := []string{cli.ResponseYes, cli.ResponseNo}
+	indexedOptions := []string{"On-Demand", "Spot"}
 
 	answer := AskQuestion(&AskQuestionInput{
 		QuestionString: question,
@@ -1201,5 +1202,6 @@ func AskSpotOrOnDemand() string {
 		OptionsString:  &optionsText,
 		IndexedOptions: indexedOptions,
 	})
+
 	return answer
 }

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1191,7 +1191,7 @@ func AskTerminationConfirmation(instanceIds []string) string {
 }
 
 func AskCapacityType() string {
-	question := "Select capacity type. Spot instances are available at up to a 90 %% discount compared to On-Demand instances,\nbut they may get interrupted by EC2 with a 2-minute warning"
+	question := fmt.Sprintf("Select capacity type. Spot instances are available at up to a 90%% discount compared to On-Demand instances,\nbut they may get interrupted by EC2 with a 2-minute warning")
 	defaultInstanceTypeText := "On-Demand"
 	optionsText := "1. On-Demand\n2. Spot\n"
 	indexedOptions := []string{"On-Demand", "Spot"}

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -38,6 +38,13 @@ import (
 
 const yesNoOption = "[ yes / no ]"
 
+var CapacityTypes = struct {
+	OnDemand, Spot string
+}{
+	OnDemand: "On-Demand",
+	Spot:     "Spot",
+}
+
 type CheckInput func(*ec2helper.EC2Helper, string) bool
 
 type AskQuestionInput struct {
@@ -1192,9 +1199,9 @@ func AskTerminationConfirmation(instanceIds []string) string {
 
 func AskCapacityType() string {
 	question := fmt.Sprintf("Select capacity type. Spot instances are available at up to a 90%% discount compared to On-Demand instances,\nbut they may get interrupted by EC2 with a 2-minute warning")
-	defaultInstanceTypeText := "On-Demand"
+	defaultInstanceTypeText := CapacityTypes.OnDemand
 	optionsText := "1. On-Demand\n2. Spot\n"
-	indexedOptions := []string{"On-Demand", "Spot"}
+	indexedOptions := []string{CapacityTypes.OnDemand, CapacityTypes.Spot}
 
 	answer := AskQuestion(&AskQuestionInput{
 		QuestionString: question,

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1188,3 +1188,18 @@ func AskTerminationConfirmation(instanceIds []string) string {
 
 	return answer
 }
+
+func AskSpotOrOnDemand() string {
+	question := "Select instance type. Spot is price efficient and effective for short term use"
+	defaultInstanceTypeText := "On-Demand"
+	optionsText := "1. On-Demand\n2. Spot\n"
+	indexedOptions := []string{cli.ResponseYes, cli.ResponseNo}
+
+	answer := AskQuestion(&AskQuestionInput{
+		QuestionString: question,
+		DefaultOption:  &defaultInstanceTypeText,
+		OptionsString:  &optionsText,
+		IndexedOptions: indexedOptions,
+	})
+	return answer
+}

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -851,6 +851,7 @@ func TestAskConfirmationWithInput_Success_NewInfrastructure(t *testing.T) {
 	testSimpleConfig.SecurityGroupIds = []string{cli.ResponseNew}
 	testSimpleConfig.AutoTerminationTimerMinutes = 0
 	testSimpleConfig.SubnetId = "us-east-2"
+	testSimpleConfig.CapacityType = "Spot"
 	testDetailedConfig.SecurityGroups = nil
 
 	initQuestionTest(t, expectedAnswer+"\n")
@@ -1102,6 +1103,16 @@ func TestAskIamProfile_Error(t *testing.T) {
 
 	_, err := question.AskIamProfile(iam)
 	th.Nok(t, err)
+
+	cleanupQuestionTest()
+}
+
+func TestAskCapacityType(t *testing.T) {
+	const expectedAnswer = "Spot"
+	initQuestionTest(t, "2\n")
+
+	answer := question.AskCapacityType()
+	th.Equals(t, expectedAnswer, answer)
 
 	cleanupQuestionTest()
 }

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -1108,7 +1108,7 @@ func TestAskIamProfile_Error(t *testing.T) {
 }
 
 func TestAskCapacityType(t *testing.T) {
-	const expectedAnswer = "Spot"
+	expectedAnswer := question.DefaultCapacityTypeText.Spot
 	initQuestionTest(t, "2\n")
 
 	answer := question.AskCapacityType()

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -25,7 +25,7 @@ import (
 func GetSimpleEc2Tags() *map[string]string {
 	now := time.Now()
 	zone, _ := now.Zone()
-	nowString := fmt.Sprintf("%02d-%02d-%02d %02d:%02d:%02d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
+	nowString := fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
 		now.Second(), zone)
 
 	tags := map[string]string{

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -56,7 +56,7 @@ func TestGetTagAsFilter(t *testing.T) {
 	actualTagFilter, err := tag.GetTagAsFilter(*tags)
 	now := time.Now()
 	zone, _ := now.Zone()
-	currTimeStr := fmt.Sprintf("%d-%d-%d %d:%d:%d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
+	currTimeStr := fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
 		now.Second(), zone)
 	// assign current time to avoid manually traversing map and checking time format
 	expectedTagAsFilter[1].Values = aws.StringSlice([]string{currTimeStr})


### PR DESCRIPTION
Issue #, if available:

Description of changes: Added new capacity type question to the simple-ec2 cli. This determines if the capacity type will be On-Demand of Spot. The capacity type was added to the launch instance description table. Tests were created and modified to test the new functionality.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. On-Demand
2. Spot
Select capacity type. Spot instances are available at up to a 90% discount compared to On-Demand instances,
but they may get interrupted by EC2 with a 2-minute warning [On-Demand]: 
